### PR TITLE
Fix build_s3_path for transformers.

### DIFF
--- a/workflows/transformers/labelling_transformer/cloud_interactions.py
+++ b/workflows/transformers/labelling_transformer/cloud_interactions.py
@@ -19,7 +19,7 @@ def build_s3_path(data_path_prefix: str,
     return: S3 path.
     rtype: str
     """
-    return f's3://{data_path_prefix}/{data_type}_{today}.csv'
+    return f'{data_path_prefix}/{data_type}_{today}.csv'
 
 
 def get_data_from_s3(bucket_name: str, s3_path: str) -> pd.DataFrame:

--- a/workflows/transformers/preprocessor_transformer/cloud_interactions.py
+++ b/workflows/transformers/preprocessor_transformer/cloud_interactions.py
@@ -19,7 +19,7 @@ def build_s3_path(data_path_prefix: str,
     return: S3 path.
     rtype: str
     """
-    return f's3://{data_path_prefix}/{data_type}_{today}.csv'
+    return f'{data_path_prefix}/{data_type}_{today}.csv'
 
 
 def get_data_from_s3(bucket_name: str, s3_path: str) -> pd.DataFrame:


### PR DESCRIPTION
## Fix build_s3_path for transformers.

### Description
Fix `build_s3_path` in `cloud_interactions.py` for the `transformers`. The error was that `s3://` was included in the front of the path being created. So, this was creating an `s3:/` and `/` folder that was not intended.

### Changelist

- `workflows/transformers/labelling_transformer/cloud_interactions.py`
- `workflows/transformers/preprocessor_transformer/cloud_interactions.py`