### PR TITLE
Add the storing of preprocessed data as json in s3 in the `preprocessor_transformer`

### DIFF
--- a/workflows/transformers/preprocessor_transformer/cloud_interactions.py
+++ b/workflows/transformers/preprocessor_transformer/cloud_interactions.py
@@ -4,10 +4,13 @@ import pandas as pd
 
 
 def build_s3_path(data_path_prefix: str,
+                  file_extension: str,
                   today: str, data_type: str) -> str:
     """Build S3 path
 
     param bucket_name: Name of S3 bucket.
+    type: str
+    param extension: Extension of file.
     type: str
     param data_path_prefix: Path prefix to data.
     type: str
@@ -19,7 +22,7 @@ def build_s3_path(data_path_prefix: str,
     return: S3 path.
     rtype: str
     """
-    return f'{data_path_prefix}/{data_type}_{today}.csv'
+    return f'{data_path_prefix}/{data_type}_{today}.{file_extension}'
 
 
 def get_data_from_s3(bucket_name: str, s3_path: str) -> pd.DataFrame:
@@ -43,7 +46,7 @@ def get_data_from_s3(bucket_name: str, s3_path: str) -> pd.DataFrame:
         raise error
 
 
-def upload_data_to_s3(bucket_name: str, s3_path: str, data: pd.DataFrame) -> None:
+def upload_data_to_s3(bucket_name: str, s3_path: str, data: any) -> None:
     """Upload data to S3
 
     param bucket_name: Name of S3 bucket.
@@ -51,7 +54,7 @@ def upload_data_to_s3(bucket_name: str, s3_path: str, data: pd.DataFrame) -> Non
     param s3_path: Path to data.
     type: str
     param data: Data to be uploaded.
-    type: pd.DataFrame
+    type: csv or json
 
     return: None
     """
@@ -59,6 +62,6 @@ def upload_data_to_s3(bucket_name: str, s3_path: str, data: pd.DataFrame) -> Non
     s3 = boto3.client('s3')
     try:
         s3.put_object(Bucket=bucket_name, Key=s3_path,
-                      Body=data.to_csv(index=False))
+                      Body=data)
     except botocore.exceptions.ClientError as error:
         raise error

--- a/workflows/transformers/preprocessor_transformer/lambda_function.py
+++ b/workflows/transformers/preprocessor_transformer/lambda_function.py
@@ -33,11 +33,16 @@ def lambda_handler(event, context) -> None:
     preprocessed_data = create_new_feature_columns(preprocessed_data)
     preprocessed_data = impute_values_in_columns(preprocessed_data)
 
-    preprocessed_data_path = build_s3_path(
-        PREPROCESSED_DESTINATION_PATH_PREFIX, today, 'preprocessed_data')
-    upload_data_to_s3(BUCKET_NAME, preprocessed_data_path, preprocessed_data)
+    preprocessed_data_csv_path = build_s3_path(
+        PREPROCESSED_DESTINATION_PATH_PREFIX, "csv", today, 'preprocessed_data')
+    preprocessed_data_json_path = build_s3_path(
+        PREPROCESSED_DESTINATION_PATH_PREFIX, "json", today, 'preprocessed_data')
+
+    upload_data_to_s3(BUCKET_NAME, preprocessed_data_csv_path, preprocessed_data.to_csv(index=False))
+    upload_data_to_s3(BUCKET_NAME, preprocessed_data_json_path, preprocessed_data.to_json(orient='records'))
 
     return {
         'status': 'success',
-        'pathPreprocessedData': preprocessed_data_path
+        'pathPreprocessedData': preprocessed_data_csv_path,
+        'pathPreprocessedDataJson': preprocessed_data_json_path
     }


### PR DESCRIPTION
## Pull Request

### Description
Adds the the ability to store the `preprocessed_data` as `json` in `s3`. This is needed for loading the `stock_metrics` data into the database.

<!-- Remember to remove the boiler plate code -->
